### PR TITLE
Add valve and leak sensor accessories

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,16 @@ A full list of supported accessory types can be found in the table below.
     <td>Rollershutter</td>
     <td>A reverse roller shutter. (mapped to WindowCovering HomeKit type)</td>
   </tr>
+  <tr>
+    <td>LeakSensor</td>
+    <td>Switch</td>
+    <td>A water leak sensor (mapped to LeakSensor HomeKit type)</td>
+  </tr>
+  <tr>
+    <td>Valve</td>
+    <td>Switch</td>
+    <td>A water valve (mapped to Valve HomeKit type with Generic ValveType)</td>
+  </tr>
 </table>
 
 See the sample below for example items:
@@ -151,3 +161,7 @@ Version 0.0.10
 
 Version 0.0.11
 + Added build status in README.
+
+Version (unreleased)
++ Added Valve type
++ Added LeakSensor type

--- a/src/accessories/leakSensorAccessory.ts
+++ b/src/accessories/leakSensorAccessory.ts
@@ -1,0 +1,58 @@
+'use strict';
+
+import { AbstractAccessory } from './abstracts/abstractAccessory';
+import { OpenHAB2DeviceInterface } from '../models/platform/openHAB2DeviceInterface';
+import { Deferred } from 'ts-deferred';
+
+export class LeakSensorAccessory extends AbstractAccessory {
+
+  setOtherServices() {
+    this.otherService = this.getService(this.hapService.LeakSensor, this.displayName);
+
+    this.getCharacteristic(this.hapCharacteristic.LeakDetected, this.getOtherService())
+      .on('get', this.getLeakDetectedState.bind(this))
+      .setValue(this.state === 'ON', () => {}, 'init');
+  };
+
+  static isValid(device) {
+    return device.tags.indexOf('LeakSensor') > -1
+  }
+
+  updateCharacteristics(message: string) {
+    this.platform.log("updateCharacteristics", this.name, message)
+
+    let characteristicOnDeferred: Deferred<string> = new Deferred<string>();
+    let characteristicsUpdated : [Promise<string>] = [characteristicOnDeferred.promise];
+
+    this.getCharacteristic(this.hapCharacteristic.LeakDetected, this.getOtherService())
+      .setValue(message === 'ON', () => {
+        this.state = message;
+        characteristicOnDeferred.resolve(message);
+      }, 'remote');
+
+    return Promise.all<string>(characteristicsUpdated);
+  };
+
+  getLeakDetectedState(callback) {
+    this.platform.log(`iOS - request leak detected state from <${this.name}>`);
+    this.platform.openHAB2Client.getDeviceProperties(this.name)
+      .then((device: OpenHAB2DeviceInterface) => {
+        this.platform.log(`OpenHAB2 HTTP - response from <${this.name}>: ${device.state}`);
+
+        // Handles Color item casted to Leakable (ex. 347.154924,92.558087,100)
+        if (device.state.split(',').length === 3) {
+          if (parseInt(device.state.split(',')[2]) > 0) {
+            device.state = 'ON';
+          }
+        // Handles Dimmer item casted to Leakable (ex. 100)
+        } else if (parseInt(device.state) > 0) {
+          device.state = 'ON';
+        }
+        callback(undefined, device.state === 'ON');
+      })
+      .catch((err) => {
+        this.platform.log(`OpenHAB2 HTTP - error from <${this.name}>`, err);
+        callback('');
+      });
+  };
+}

--- a/src/accessories/valveAccessory.ts
+++ b/src/accessories/valveAccessory.ts
@@ -1,0 +1,87 @@
+'use strict';
+
+import { AbstractAccessory } from './abstracts/abstractAccessory';
+import { OpenHAB2DeviceInterface } from '../models/platform/openHAB2DeviceInterface';
+import { Deferred } from 'ts-deferred';
+
+export class ValveAccessory extends AbstractAccessory {
+
+  setOtherServices() {
+    this.otherService = this.getService(this.hapService.Valve, this.displayName);
+
+    this.getCharacteristic(this.hapCharacteristic.InUse, this.getOtherService())
+      .on('get', this.getActiveState.bind(this))
+      .setValue(this.state === 'ON', () => {}, 'init');
+
+    this.getCharacteristic(this.hapCharacteristic.Active, this.getOtherService())
+      .on('get', this.getActiveState.bind(this))
+      .on('set', this.setActiveState.bind(this))
+      .setValue(this.state === 'ON', () => {}, 'init');
+
+    this.getCharacteristic(this.hapCharacteristic.ValveType, this.getOtherService())
+      .updateValue(this.hapCharacteristic.ValveType.GENERIC_VALVE);
+  };
+
+  static isValid(device) {
+    return device.tags.indexOf('Valve') > -1
+  }
+
+  updateCharacteristics(message: string) {
+    this.platform.log("updateCharacteristics", this.name, message)
+
+    let characteristicOnDeferred: Deferred<string> = new Deferred<string>();
+    let characteristicsUpdated : [Promise<string>] = [characteristicOnDeferred.promise];
+
+    [this.hapCharacteristic.Active, this.hapCharacteristic.InUse].forEach((characteristic) => {
+      this.getCharacteristic(characteristic, this.getOtherService())
+        .setValue(message === 'ON', () => {
+          this.state = message;
+          characteristicOnDeferred.resolve(message);
+        }, 'remote');
+    });
+
+    return Promise.all<string>(characteristicsUpdated);
+  };
+
+  getActiveState(callback) {
+    this.platform.log(`iOS - request leak detected state from <${this.name}>`);
+    this.platform.openHAB2Client.getDeviceProperties(this.name)
+      .then((device: OpenHAB2DeviceInterface) => {
+        this.platform.log(`OpenHAB2 HTTP - response from <${this.name}>: ${device.state}`);
+
+        // Handles Color item casted to Leakable (ex. 347.154924,92.558087,100)
+        if (device.state.split(',').length === 3) {
+          if (parseInt(device.state.split(',')[2]) > 0) {
+            device.state = 'ON';
+          }
+        // Handles Dimmer item casted to Leakable (ex. 100)
+        } else if (parseInt(device.state) > 0) {
+          device.state = 'ON';
+        }
+        callback(undefined, device.state === 'ON');
+      })
+      .catch((err) => {
+        this.platform.log(`OpenHAB2 HTTP - error from <${this.name}>`, err);
+        callback('');
+      });
+  };
+
+  setActiveState(value: string, callback: Function, context: string) {
+    if (context === 'remote' || context === 'init') {
+      callback(null);
+      return;
+    }
+
+    let command = value ? 'ON' : 'OFF';
+
+    this.platform.log(`iOS - send message to <${this.name}>: ${command}`);
+    this.platform.openHAB2Client.executeDeviceAction(this.name, command)
+      .then(() => {
+        this.platform.log(`OpenHAB2 HTTP - response from <${this.name}>: completed.`);
+      })
+      .catch((err) => {
+        this.platform.log(`OpenHAB2 HTTP - error from <${this.name}>:`, err);
+      })
+      .then(() => callback());
+  };
+}

--- a/src/services/accessoryFactory.ts
+++ b/src/services/accessoryFactory.ts
@@ -2,6 +2,8 @@
 
 import { SwitchAccessory } from '../accessories/switchAccessory';
 import { LightbulbAccessory } from '../accessories/lightbulbAccessory';
+import { LeakSensorAccessory } from '../accessories/leakSensorAccessory';
+import { ValveAccessory } from '../accessories/valveAccessory';
 import { DimmerAccessory } from '../accessories/dimmerAccessory';
 import { OpenHAB2DeviceInterface } from '../models/platform/openHAB2DeviceInterface';
 import { OpenHAB2Platform } from '../platform/openHAB2Platform';
@@ -15,7 +17,9 @@ export class AccessoryFactory {
     Lighting: LightbulbAccessory,
     Dimmable: DimmerAccessory,
     WindowCovering: RollershutterAccessory,
-    ReverseWindowCovering: ReverseRollershutterAccessory
+    ReverseWindowCovering: ReverseRollershutterAccessory,
+    LeakSensor: LeakSensorAccessory,
+    Valve: ValveAccessory
   };
 
   static isValid(device: OpenHAB2DeviceInterface): boolean {


### PR DESCRIPTION
In this PR we add basic support for Valve and LeakSensor homekit types. I've added these to support control and status of my Z-wave connected Dome leak sensor system with Homekit.