### PR TITLE
Added support for contact sensor accessory

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ A full list of supported accessory types can be found in the table below.
     <td>Switch</td>
     <td>A water valve (mapped to Valve HomeKit type with Generic ValveType)</td>
   </tr>
+  <tr>
+    <td>ContactSensor</td>
+    <td>Contact</td>
+    <td>A contact sensor (mapped to ContactSensor HomeKit type)</td>
+  </tr>  
 </table>
 
 See the sample below for example items:
@@ -165,3 +170,4 @@ Version 0.0.11
 Version (unreleased)
 + Added Valve type
 + Added LeakSensor type
++ Added ContactSensor type

--- a/src/accessories/contactAccessory.ts
+++ b/src/accessories/contactAccessory.ts
@@ -1,0 +1,58 @@
+'use strict';
+
+import { AbstractAccessory } from './abstracts/abstractAccessory';
+import { OpenHAB2DeviceInterface } from '../models/platform/openHAB2DeviceInterface';
+import { Deferred } from 'ts-deferred';
+
+export class ContactAccessory extends AbstractAccessory {
+  
+   setOtherServices() {
+    this.otherService = this.getService(this.hapService.ContactSensor, this.displayName);
+    
+    this.getCharacteristic(this.hapCharacteristic.ContactSensorState, this.getOtherService())
+      .on('get', this.getContactDetectedState.bind(this))
+      .setValue(this.state === 'ON', () => {}, 'init');
+  };
+
+  static isValid(device) {
+    return device.tags.indexOf('ContactSensor') > -1 && ['Contact'].indexOf(device.type) > -1
+  }
+
+  updateCharacteristics(message: string) {
+    this.platform.log("updateCharacteristics", this.name, message)
+
+    let characteristicOnDeferred: Deferred<string> = new Deferred<string>();
+    let characteristicsUpdated : [Promise<string>] = [characteristicOnDeferred.promise];
+
+    this.getCharacteristic(this.hapCharacteristic.ContactSensorState, this.getOtherService())
+      .setValue(message === 'OPEN', () => {
+        this.state = message;
+        characteristicOnDeferred.resolve(message);
+      }, 'remote');
+
+    return Promise.all<string>(characteristicsUpdated);
+  };
+
+  getContactDetectedState(callback) {
+    this.platform.log(`iOS - request contact detected state from <${this.name}>`);
+    this.platform.openHAB2Client.getDeviceProperties(this.name)
+      .then((device: OpenHAB2DeviceInterface) => {
+        this.platform.log(`OpenHAB2 HTTP - response from <${this.name}>: ${device.state}`);
+
+        // Handles Color item casted to Leakable (ex. 347.154924,92.558087,100)
+        if (device.state.split(',').length === 3) {
+          if (parseInt(device.state.split(',')[2]) > 0) {
+            device.state = 'OPEN';
+          }
+        // Handles Dimmer item casted to Leakable (ex. 100)
+        } else if (parseInt(device.state) > 0) {
+          device.state = 'OPEN';
+        }
+        callback(undefined, device.state === 'OPEN');
+      })
+      .catch((err) => {
+        this.platform.log(`OpenHAB2 HTTP - error from <${this.name}>`, err);
+        callback('');
+      });
+  };
+}

--- a/src/services/accessoryFactory.ts
+++ b/src/services/accessoryFactory.ts
@@ -9,6 +9,7 @@ import { OpenHAB2DeviceInterface } from '../models/platform/openHAB2DeviceInterf
 import { OpenHAB2Platform } from '../platform/openHAB2Platform';
 import { RollershutterAccessory } from '../accessories/rollershutterAccessory';
 import { ReverseRollershutterAccessory } from '../accessories/reverseRollershutterAccessory';
+import { ContactAccessory } from '../accessories/contactAccessory';
 
 export class AccessoryFactory {
 
@@ -19,7 +20,8 @@ export class AccessoryFactory {
     WindowCovering: RollershutterAccessory,
     ReverseWindowCovering: ReverseRollershutterAccessory,
     LeakSensor: LeakSensorAccessory,
-    Valve: ValveAccessory
+    Valve: ValveAccessory,
+    ContactSensor: ContactAccessory
   };
 
   static isValid(device: OpenHAB2DeviceInterface): boolean {


### PR DESCRIPTION
With this PR it is possible to export contact sensors to HomeKit.
Due to this it is possible to check the state of (e.g. a door or window) in the "home" app.

Within the Home application it is possible to change the type of the sensor to:
- garage door opener
- contact sensor
- window
- door
- jalousie